### PR TITLE
listing username and uuid now stored in front end as session

### DIFF
--- a/491A/src/app/protected/messages/messages.component.html
+++ b/491A/src/app/protected/messages/messages.component.html
@@ -1,7 +1,7 @@
 <app-header></app-header>
 
 <div class="message-user-container">
-  <h2>Message User</h2>
+  <h2>Message User: {{this.listingUsername}}</h2>
   <input [(ngModel)]="userMessage" placeholder="Enter your message" />
   <button (click)="sendEmail()" mat-raised-button color="primary">Send</button>
   <div *ngIf="messageSent" class="message-sent-text">Message Sent!</div>

--- a/491A/src/app/protected/messages/messages.component.ts
+++ b/491A/src/app/protected/messages/messages.component.ts
@@ -45,7 +45,7 @@ export class MessagesComponent implements OnInit {
   
     const requestData = {
       recipientEmail: this.listingUsername,
-      subject: "ResellU User: " + this.username + " Wants to Buy Your Item",
+      subject: "ResellU User: " + this.username + " | Wants to Buy Your Item",
       message: this.userMessage,
       sourceEmail: this.username, // Uses the logged in username and sends it to lambda to get email of specific user
       listingUuid: this.listingUuid

--- a/491A/src/app/protected/services/listing.service.ts
+++ b/491A/src/app/protected/services/listing.service.ts
@@ -13,9 +13,21 @@ export class ListingService {
   private currentListingUsernameSubject = new BehaviorSubject<string>('');
   private currentListingUuidSubject = new BehaviorSubject<string>('');
 
-  constructor(private http: HttpClient, private auth: AuthService, private router: Router) { }
+  constructor(private http: HttpClient, private auth: AuthService, private router: Router) { 
+    const storedListingUsername = sessionStorage.getItem('currentListingUsername');
+    const storedListingUuid = sessionStorage.getItem('currentListingUuid');
+
+    if (storedListingUsername) {
+      this.currentListingUsernameSubject.next(storedListingUsername);
+    }
+
+    if (storedListingUuid) {
+      this.currentListingUuidSubject.next(storedListingUuid);
+    }
+  }
 
   setCurrentListingUsername(username: string): void {
+    sessionStorage.setItem('currentListingUsername', username);
     this.currentListingUsernameSubject.next(username);
   }
 
@@ -24,6 +36,7 @@ export class ListingService {
   }
 
   setCurrentListingUuid(uuid: string): void {
+    sessionStorage.setItem('currentListingUuid', uuid);
     this.currentListingUuidSubject.next(uuid);
   }
 

--- a/491A/src/app/report-listing/report-listing.component.ts
+++ b/491A/src/app/report-listing/report-listing.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { UsernameService } from '../protected/services/username.service';
+import { ListingService } from '../protected/services/listing.service';
 
 @Component({
   selector: 'app-report-listing',
@@ -13,8 +14,18 @@ export class ReportListingComponent {
   reportReason: string = '';
   selectedOption: string = '';
   username: string | null = null;
+  listingUuid: any;
 
-  constructor(private http: HttpClient, private snackBar: MatSnackBar, private usernameService: UsernameService) {}
+  constructor(private http: HttpClient, private snackBar: MatSnackBar, private usernameService: UsernameService, private listingService: ListingService) {
+
+    this.listingService.getCurrentListingUuid().subscribe(
+      (listingUuid) => {
+        this.listingUuid = listingUuid;
+      }
+    );
+  }
+
+
 
   ngOnInit(): void {
     this.usernameService.getUsername().subscribe(username => {
@@ -44,7 +55,7 @@ export class ReportListingComponent {
       return;
     }
 
-    const reportSubject = this.username ? `Listing Report: ${this.username}` : 'Listing Report';
+    const reportSubject = this.listingUuid ? `Listing Report: ${this.listingUuid}` : 'Listing Report';
 
     // Make an HTTP request to your Lambda function
     const lambdaEndpoint = 'https://gdl0m2hqx0.execute-api.us-east-1.amazonaws.com/dev/report-user'; 
@@ -59,6 +70,8 @@ export class ReportListingComponent {
         this.snackBar.open('Report submitted successfully.', 'Close', {
           duration: 3000,
         });
+
+        this.reportReason = '';
       },
       (error) => {
         console.error('Error submitting report:', error);

--- a/491A/src/app/report-user/report-user.component.ts
+++ b/491A/src/app/report-user/report-user.component.ts
@@ -77,6 +77,8 @@ export class ReportUserComponent {
         this.snackBar.open('Report submitted successfully.', 'Close', {
           duration: 3000,
         });
+
+        this.reportReason = '';
       },
       (error) => {
         console.error('Error submitting report:', error);


### PR DESCRIPTION
Before, if the user reloads the message or report-listing page, the listing's username and uuid would be lost. Now it is stored as session so it will persist if the user reloads the page.